### PR TITLE
Change previous/next month opacity from 2/10 to 3/10

### DIFF
--- a/Upcoming Calendar Indicator/Upcoming Calendar Indicatorb.js
+++ b/Upcoming Calendar Indicator/Upcoming Calendar Indicatorb.js
@@ -657,7 +657,7 @@ async function createWidget() {
         addWidgetTextLine(dateStackUp, `${month[i][j]}`,
         {
           color: '',//textColor,
-          opacity: (prevMonth||nextMonth) ? (2/10) : (i == sat || i == sun) ? opacity : 1,
+          opacity: (prevMonth||nextMonth) ? (3/10) : (i == sat || i == sun) ? opacity : 1,
           font: Font.boldSystemFont(10),
           align: "left",
         });


### PR DESCRIPTION
This is a tiny pull request that increases the readability of the new previous/after month display by increasing the opacity from 2/10 to 3/10.

Here is a before/after comparison:
![Dark](https://user-images.githubusercontent.com/57331134/119058844-24014880-b99d-11eb-8989-d2e20d2fdfb0.gif)
![Light](https://user-images.githubusercontent.com/57331134/119058852-282d6600-b99d-11eb-99a8-db17554a156a.gif)

This is less of a fix and more of a personal preference, but I do think the default 2/10 opacity is quite hard to read at a distance on dark mode.